### PR TITLE
Wrap projectM instance access in a mutex

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -10,6 +10,7 @@ rust-version = "1.68.2"
 libc = "*"
 sdl2 = "0.35"
 projectm-rs = "1.0.5"
+# projectm-rs = { path = "../projectm-rs" }
 #projectm-rs = { git = "https://github.com/projectM-visualizer/projectm-rs" }
 
 # gl = "0.14.0"

--- a/src/app/config.rs
+++ b/src/app/config.rs
@@ -39,6 +39,8 @@ impl Default for Config {
 
 impl App {
     pub fn load_config(&self, config: &Config) {
+        let pm = *self.pm.lock().unwrap();
+
         // load presets if provided
         if let Some(preset_path) = &config.preset_path {
             self.add_preset_path(preset_path);
@@ -46,28 +48,29 @@ impl App {
 
         // set frame rate if provided
         if let Some(frame_rate) = config.frame_rate {
-            Projectm::set_fps(self.pm, frame_rate)
+            Projectm::set_fps(pm, frame_rate)
         }
 
         // load textures if provided
         if let Some(texture_path) = &config.texture_path {
             let mut paths: Vec<String> = Vec::new();
             paths.push(texture_path.into());
-            Projectm::set_texture_search_paths(self.pm, &paths, 1);
+            Projectm::set_texture_search_paths(pm, &paths, 1);
         }
 
         // set beat sensitivity if provided
         if let Some(beat_sensitivity) = config.beat_sensitivity {
-            Projectm::set_beat_sensitivity(self.pm, beat_sensitivity);
+            Projectm::set_beat_sensitivity(pm, beat_sensitivity);
         }
 
         // set preset duration if provided
         if let Some(preset_duration) = config.preset_duration {
-            Projectm::set_preset_duration(self.pm, preset_duration);
+            Projectm::set_preset_duration(pm, preset_duration);
         }
     }
 
     pub fn get_frame_rate(&self) -> FrameRate {
-        Projectm::get_fps(self.pm)
+        let pm = *self.pm.lock().unwrap();
+        Projectm::get_fps(pm)
     }
 }

--- a/src/app/main_loop.rs
+++ b/src/app/main_loop.rs
@@ -81,7 +81,11 @@ impl App {
                     // Next audio capture input device (ctl-I, cmd-I)
                     Event::KeyUp {
                         keycode: Some(Keycode::I),
-                        keymod: sdl2::keyboard::Mod::LCTRLMOD,
+                        keymod:
+                            sdl2::keyboard::Mod::LCTRLMOD
+                            | sdl2::keyboard::Mod::RCTRLMOD
+                            | sdl2::keyboard::Mod::LGUIMOD
+                            | sdl2::keyboard::Mod::RGUIMOD,
                         ..
                     } => {
                         self.audio.open_next_device();
@@ -97,7 +101,10 @@ impl App {
             dummy_audio::generate_random_audio_data(self.pm);
 
             // render a frame
-            Projectm::render_frame(self.pm);
+            {
+                let pm = *self.pm.lock().unwrap();
+                Projectm::render_frame(pm);
+            }
 
             // swap buffers
             self.window.gl_swap_window();


### PR DESCRIPTION
We share this projectM handle with the AudioCallback which runs in its own thread, so we should probably wrap all of our fiddling with the instance in a mutex.

Someone please let me know if this is correct at all!