### PR TITLE
Fix "The specified window isn't an OpenGL window" error

### DIFF
--- a/src/app.rs
+++ b/src/app.rs
@@ -47,6 +47,7 @@ impl App {
         // create window
         let mut window = video_subsystem
             .window("ProjectM", 1024, 768)
+            .opengl()
             .build()
             .expect("could not initialize video subsystem");
 


### PR DESCRIPTION
On Arch Linux, after successfully building the app, I came across this error

```
SDL version: 3.2.16

thread 'main' panicked at src/app.rs:54:53:
called `Result::unwrap()` on an `Err` value: Error("The specified window isn't an OpenGL window")
note: run with `RUST_BACKTRACE=1` environment variable to display a backtrace
```

The fix was a simple added flag to the SDL window.